### PR TITLE
Generalized ppat

### DIFF
--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -145,19 +145,23 @@ module Pat = struct
      ppat_loc = loc;
      ppat_loc_stack = [];
      ppat_attributes = attrs}
+  let mk_gen = mk
   let attr d a = {d with ppat_attributes = d.ppat_attributes @ [a]}
 
   let any ?loc ?attrs () = mk ?loc ?attrs Ppat_any
   let var ?loc ?attrs a = mk ?loc ?attrs (Ppat_var a)
   let alias ?loc ?attrs a b = mk ?loc ?attrs (Ppat_alias (a, b))
   let constant ?loc ?attrs a = mk ?loc ?attrs (Ppat_constant a)
+  let constant_gen = constant
   let interval ?loc ?attrs a b = mk ?loc ?attrs (Ppat_interval (a, b))
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Ppat_tuple a)
+  let tuple_gen = tuple
   let construct ?loc ?attrs a b = mk ?loc ?attrs (Ppat_construct (a, b))
   let variant ?loc ?attrs a b = mk ?loc ?attrs (Ppat_variant (a, b))
   let record ?loc ?attrs a b = mk ?loc ?attrs (Ppat_record (a, b))
   let array ?loc ?attrs a = mk ?loc ?attrs (Ppat_array a)
   let or_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_or (a, b))
+  let or_gen = or_
   let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_constraint (a, b))
   let type_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_type a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_lazy a)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -101,14 +101,20 @@ module Typ :
 module Pat:
   sig
     val mk: ?loc:loc -> ?attrs:attrs -> pattern_desc -> pattern
+    val mk_gen: ?loc:loc -> ?attrs:attrs ->
+      ('l,'c) gen_pattern_desc -> ('l,'c) gen_pattern
     val attr:pattern -> attribute -> pattern
 
     val any: ?loc:loc -> ?attrs:attrs -> unit -> pattern
     val var: ?loc:loc -> ?attrs:attrs -> str -> pattern
     val alias: ?loc:loc -> ?attrs:attrs -> pattern -> str -> pattern
     val constant: ?loc:loc -> ?attrs:attrs -> constant -> pattern
+    val constant_gen: ?loc:loc -> ?attrs:attrs -> constant ->
+      ('l,'c) gen_pattern
     val interval: ?loc:loc -> ?attrs:attrs -> constant -> constant -> pattern
     val tuple: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
+    val tuple_gen: ?loc:loc -> ?attrs:attrs ->
+      ('l,'c) gen_pattern list -> ('l,'c) gen_pattern
     val construct: ?loc:loc -> ?attrs:attrs ->
       lid -> (str list * pattern) option -> pattern
     val variant: ?loc:loc -> ?attrs:attrs -> label -> pattern option -> pattern
@@ -116,6 +122,8 @@ module Pat:
                 -> pattern
     val array: ?loc:loc -> ?attrs:attrs -> pattern list -> pattern
     val or_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern -> pattern
+    val or_gen: ?loc:loc -> ?attrs:attrs ->
+      ('l,'c) gen_pattern -> ('l,'c) gen_pattern -> ('l,'c) gen_pattern
     val constraint_: ?loc:loc -> ?attrs:attrs -> pattern -> core_type -> pattern
     val type_: ?loc:loc -> ?attrs:attrs -> lid -> pattern
     val lazy_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -199,8 +199,8 @@ and 'a gen_pattern =
      ppat_attributes: attributes; (* ... [@id1] [@id2] *)
     }
 
-and pattern_desc = Longident.t loc gen_pattern_desc
-and 'a gen_pattern_desc =
+and pattern_desc = (Longident.t loc, Longident.t loc) gen_pattern_desc
+and ('label,'constr) gen_pattern_desc =
   | Ppat_any
         (* _ *)
   | Ppat_var of string loc
@@ -220,7 +220,7 @@ and 'a gen_pattern_desc =
            Invariant: n >= 2
         *)
   | Ppat_construct of
-      Longident.t loc * (string loc list * pattern) option
+      'constr * (string loc list * pattern) option
         (* C                    None
            C P                  Some ([], P)
            C (P1, ..., Pn)      Some ([], Ppat_tuple [P1; ...; Pn])
@@ -230,7 +230,7 @@ and 'a gen_pattern_desc =
         (* `A             (None)
            `A P           (Some P)
          *)
-  | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+  | Ppat_record of ('label * pattern) list * closed_flag
         (* { l1=P1; ...; ln=Pn }     (flag = Closed)
            { l1=P1; ...; ln=Pn; _}   (flag = Open)
 

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -190,15 +190,17 @@ and object_field_desc =
 
 (* Patterns *)
 
-and pattern =
+and pattern = Longident.t loc gen_pattern
+and 'a gen_pattern =
     {
-     ppat_desc: pattern_desc;
+     ppat_desc: 'a gen_pattern_desc;
      ppat_loc: Location.t;
      ppat_loc_stack: location_stack;
      ppat_attributes: attributes; (* ... [@id1] [@id2] *)
     }
 
-and pattern_desc =
+and pattern_desc = Longident.t loc gen_pattern_desc
+and 'a gen_pattern_desc =
   | Ppat_any
         (* _ *)
   | Ppat_var of string loc

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -190,10 +190,10 @@ and object_field_desc =
 
 (* Patterns *)
 
-and pattern = Longident.t loc gen_pattern
-and 'a gen_pattern =
+and pattern = (Longident.t loc, Longident.t loc) gen_pattern
+and ('label,'constr) gen_pattern =
     {
-     ppat_desc: 'a gen_pattern_desc;
+     ppat_desc: ('label, 'constr) gen_pattern_desc;
      ppat_loc: Location.t;
      ppat_loc_stack: location_stack;
      ppat_attributes: attributes; (* ... [@id1] [@id2] *)
@@ -205,7 +205,7 @@ and ('label,'constr) gen_pattern_desc =
         (* _ *)
   | Ppat_var of string loc
         (* x *)
-  | Ppat_alias of pattern * string loc
+  | Ppat_alias of 'pattern * string loc
         (* P as 'a *)
   | Ppat_constant of constant
         (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
@@ -214,37 +214,37 @@ and ('label,'constr) gen_pattern_desc =
 
            Other forms of interval are recognized by the parser
            but rejected by the type-checker. *)
-  | Ppat_tuple of pattern list
+  | Ppat_tuple of 'pattern list
         (* (P1, ..., Pn)
 
            Invariant: n >= 2
         *)
   | Ppat_construct of
-      'constr * (string loc list * pattern) option
+      'constr * (string loc list * 'pattern) option
         (* C                    None
            C P                  Some ([], P)
            C (P1, ..., Pn)      Some ([], Ppat_tuple [P1; ...; Pn])
            C (type a b) P       Some ([a; b], P)
          *)
-  | Ppat_variant of label * pattern option
+  | Ppat_variant of label * 'pattern option
         (* `A             (None)
            `A P           (Some P)
          *)
-  | Ppat_record of ('label * pattern) list * closed_flag
+  | Ppat_record of ('label * 'pattern) list * closed_flag
         (* { l1=P1; ...; ln=Pn }     (flag = Closed)
            { l1=P1; ...; ln=Pn; _}   (flag = Open)
 
            Invariant: n > 0
          *)
-  | Ppat_array of pattern list
+  | Ppat_array of 'pattern list
         (* [| P1; ...; Pn |] *)
-  | Ppat_or of pattern * pattern
+  | Ppat_or of 'pattern * 'pattern
         (* P1 | P2 *)
-  | Ppat_constraint of pattern * core_type
+  | Ppat_constraint of 'pattern * core_type
         (* (P : T) *)
   | Ppat_type of Longident.t loc
         (* #tconst *)
-  | Ppat_lazy of pattern
+  | Ppat_lazy of 'pattern
         (* lazy P *)
   | Ppat_unpack of string option loc
         (* (module P)        Some "P"
@@ -253,12 +253,13 @@ and ('label,'constr) gen_pattern_desc =
            Note: (module P : S) is represented as
            Ppat_constraint(Ppat_unpack, Ptyp_package)
          *)
-  | Ppat_exception of pattern
+  | Ppat_exception of 'pattern
         (* exception P *)
   | Ppat_extension of extension
         (* [%id] *)
-  | Ppat_open of Longident.t loc * pattern
+  | Ppat_open of Longident.t loc * 'pattern
         (* M.(P) *)
+  constraint 'pattern = ('label,'constr) gen_pattern
 
 (* Value expressions *)
 

--- a/testsuite/tests/asmcomp/prevent_fma.ml
+++ b/testsuite/tests/asmcomp/prevent_fma.ml
@@ -1,0 +1,22 @@
+(* TEST
+  * native
+*)
+
+let ( *. ) x y = Sys.opaque_identity (x *. y)
+(* Using opaque_identity should prevent use of FMA. *)
+
+let f x = (x *. x -. x *. x)
+    (* The expression above can be compiled in two ways:
+       1. First evaluating x' = x *. x, then x' -. x'
+       The result is obviously zero.
+       2. First evaluating x' = x *. x, then x *. x -. x' as a single evaluation
+       step, using fused-multiply-add (or rather sub here).
+       FMA computes with increased precision because no rounding of the
+       intermediate computation happens.
+       In this case, the result is not always exactly 0.
+
+       See issue #10323. *)
+
+
+let () =
+  assert (Int64.bits_of_float (f (sqrt 2.0)) = 0L)

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -83,14 +83,12 @@ val complete_constrs :
       are GADT constructors ([PE_gadt_cases]).
  *)
 type pat_explosion = PE_single | PE_gadt_cases
+type typed_pattern =
+    (label_description, constructor_description) Parsetree.gen_pattern
 type ppat_of_type =
   | PT_empty
   | PT_any
-  | PT_pattern of
-      pat_explosion *
-      Parsetree.pattern *
-      (string, constructor_description) Hashtbl.t *
-      (string, label_description) Hashtbl.t
+  | PT_pattern of pat_explosion * typed_pattern
 
 val ppat_of_type: Env.t -> type_expr -> ppat_of_type
 
@@ -107,15 +105,10 @@ val pressure_variants_in_computation_pattern:
     [refute] indicates that [check_unused] was called on a refutation clause.
  *)
 val check_partial:
-    ((string, constructor_description) Hashtbl.t ->
-     (string, label_description) Hashtbl.t ->
-     Parsetree.pattern -> pattern option) ->
+    (typed_pattern -> pattern option) ->
     Location.t -> value case list -> partial
 val check_unused:
-    (bool ->
-     (string, constructor_description) Hashtbl.t ->
-     (string, label_description) Hashtbl.t ->
-     Parsetree.pattern -> pattern option) ->
+    (bool -> typed_pattern -> pattern option) ->
     value case list -> unit
 
 (* Irrefutability tests *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1753,9 +1753,10 @@ and type_pat_aux
         pat_attributes = sp.ppat_attributes;
         pat_env = !env })
   | Ppat_construct(lid_or_constr, sarg) ->
-      let constr =
+      let lid, constr =
         match mode with
-        | Counter_example _ -> lid_or_constr
+        | Counter_example _ ->
+            Longident.Lident lid_or_constr.cstr_name, lid_or_constr
         | Normal ->
         let lid = lid_or_constr in
         let expected_ty_info =
@@ -1770,10 +1771,11 @@ and type_pat_aux
         in
         let candidates =
           Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !env in
-        wrap_disambiguate "This variant pattern is expected to have"
-          (mk_expected expected_ty)
-          (Constructor.disambiguate Env.Pattern lid !env expected_ty_info)
-          candidates
+        (lid,
+         wrap_disambiguate "This variant pattern is expected to have"
+           (mk_expected expected_ty)
+           (Constructor.disambiguate Env.Pattern lid !env expected_ty_info)
+           candidates)
       in
       if constr.cstr_generalized && must_backtrack_on_gadt then
         raise Need_backtrack;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1343,10 +1343,11 @@ let check_scope_escape loc env level ty =
                  Pattern_type_clash(Errortrace.unification_error ~trace, None)))
 
 type 'a pattern_checking_mode =
-  | Normal : Longident.t loc pattern_checking_mode
+  | Normal : (Longident.t loc, Longident.t loc) pattern_checking_mode
   (** We are checking user code. *)
   | Counter_example :
-    counter_example_checking_info -> Path.t pattern_checking_mode
+    counter_example_checking_info ->
+    (label_description, constructor_description) pattern_checking_mode
   (** In [Counter_example] mode, we are checking a counter-example
       candidate produced by Parmatch. This is a syntactic pattern that
       represents a set of values by using or-patterns (p_1 | ... | p_n)
@@ -1578,10 +1579,10 @@ let as_comp_pattern
    In counter-example mode, [Empty_branch] is raised when the counter-example
    does not match any value.  *)
 let rec type_pat
-  : type k r p. k pattern_category ->
+  : type k r l c. k pattern_category ->
       no_existentials: existential_restriction option ->
-      mode: pattern_checking_mode -> env: Env.t ref -> p Parsetree.pattern ->
-      type_expr -> (k general_pattern -> r) -> r
+      mode: (l,c) pattern_checking_mode -> env: Env.t ref ->
+      (l,c) Parsetree.pattern -> type_expr -> (k general_pattern -> r) -> r
   = fun category ~no_existentials ~mode
         ~env sp expected_ty k ->
   Builtin_attributes.warning_scope sp.ppat_attributes

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1342,10 +1342,11 @@ let check_scope_escape loc env level ty =
                  env,
                  Pattern_type_clash(Errortrace.unification_error ~trace, None)))
 
-type pattern_checking_mode =
-  | Normal
+type 'a pattern_checking_mode =
+  | Normal : Longident.t loc pattern_checking_mode
   (** We are checking user code. *)
-  | Counter_example of counter_example_checking_info
+  | Counter_example :
+    counter_example_checking_info -> Path.t pattern_checking_mode
   (** In [Counter_example] mode, we are checking a counter-example
       candidate produced by Parmatch. This is a syntactic pattern that
       represents a set of values by using or-patterns (p_1 | ... | p_n)
@@ -1577,9 +1578,9 @@ let as_comp_pattern
    In counter-example mode, [Empty_branch] is raised when the counter-example
    does not match any value.  *)
 let rec type_pat
-  : type k r . k pattern_category ->
+  : type k r p. k pattern_category ->
       no_existentials: existential_restriction option ->
-      mode: pattern_checking_mode -> env: Env.t ref -> Parsetree.pattern ->
+      mode: pattern_checking_mode -> env: Env.t ref -> p Parsetree.pattern ->
       type_expr -> (k general_pattern -> r) -> r
   = fun category ~no_existentials ~mode
         ~env sp expected_ty k ->


### PR DESCRIPTION
This PR introduces parameters to `Parsetree.pattern` in order to avoid the use of fresh constructor / label names in `Parmatch.Conv`.

We intend to completely remove `Parmatch.Conv` in another PR, and this PR should be compared to it.