### PR TITLE
#13585: make `unify_gadt` non-symmetrical

### DIFF
--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -44,12 +44,7 @@ type _ t = W : int M.p t
 
 let f (W: _ M.p t) = ()
 [%%expect{|
-Line 1, characters 7-8:
-1 | let f (W: _ M.p t) = ()
-           ^
-Error: This pattern matches values of type "int M.p t"
-       but a pattern was expected which matches values of type "$0 M.p t"
-       The type constructor "$0" would escape its scope
+val f : int M.p t -> unit = <fun>
 |}]
 
 let f (W: _ t) = ()

--- a/testsuite/tests/typing-gadts/pr13579.ml
+++ b/testsuite/tests/typing-gadts/pr13579.ml
@@ -51,3 +51,14 @@ let f (W: _ t) = ()
 [%%expect{|
 val f : int M.p t -> unit = <fun>
 |}]
+
+let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
+[%%expect{|
+Line 1, characters 16-21:
+1 | let f (type a) (Equal : ('a M.p * a, 'b M.p * int) Type.eq) = ();;
+                    ^^^^^
+Error: This pattern matches values of type "($'a M.p * a, $'a M.p * a) Type.eq"
+       but a pattern was expected which matches values of type
+         "($'a M.p * a, 'b M.p * int) Type.eq"
+       The type constructor "$'a" would escape its scope
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3259,15 +3259,28 @@ let unify uenv ty1 ty2 =
 
 let unify_gadt (penv : Pattern_env.t) ty1 ty2 =
   let equated_types = TypePairs.create 0 in
-  let uenv = Pattern
-      { penv;
-        equated_types;
-        assume_injective = true;
-        unify_eq_set = TypePairs.create 11; }
-  in
-  with_univar_pairs [] (fun () ->
+  let do_unify_gadt () =
+    let uenv = Pattern
+        { penv;
+          equated_types;
+          assume_injective = true;
+          unify_eq_set = TypePairs.create 11; }
+    in
     unify uenv ty1 ty2;
-    equated_types)
+    equated_types
+  in
+  let closed = closed_type_expr ty1 && closed_type_expr ty2 in
+  if closed then with_univar_pairs [] do_unify_gadt else
+  let snap = Btype.snapshot () in
+  try
+    (* If there are free variables, first try normal unification *)
+    let uenv = Expression {env = penv.env; in_subst = false} in
+    with_univar_pairs [] (fun () -> unify uenv ty1 ty2);
+    equated_types
+  with Unify _ ->
+    (* If it fails, retry in pattern mode *)
+    Btype.backtrack snap;
+    with_univar_pairs [] do_unify_gadt
 
 let unify_var uenv t1 t2 =
   if eq_type t1 t2 then () else

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3269,8 +3269,8 @@ let unify_gadt (penv : Pattern_env.t) ty1 ty2 =
     unify uenv ty1 ty2;
     equated_types
   in
-  let closed = closed_type_expr ty1 && closed_type_expr ty2 in
-  if closed then with_univar_pairs [] do_unify_gadt else
+  let no_leak = penv.allow_recursive_equations || closed_type_expr ty2 in
+  if no_leak then with_univar_pairs [] do_unify_gadt else
   let snap = Btype.snapshot () in
   try
     (* If there are free variables, first try normal unification *)

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3257,7 +3257,7 @@ let unify uenv ty1 ty2 =
       undo_compress snap;
       raise (Unify (expand_to_unification_error (get_env uenv) trace))
 
-let unify_gadt (penv : Pattern_env.t) ty1 ty2 =
+let unify_gadt (penv : Pattern_env.t) ~pat:ty1 ty2 =
   let equated_types = TypePairs.create 0 in
   let do_unify_gadt () =
     let uenv = Pattern

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -275,7 +275,11 @@ val unify_gadt:
         Pattern_env.t -> type_expr -> type_expr -> Btype.TypePairs.t
         (* Unify the two types given and update the environment with the
            local constraints. Raise [Unify] if not possible.
-           Returns the pairs of types that have been equated.  *)
+           Returns the pairs of types that have been equated.
+           Type variables in the first [type_expr] are assumed
+           to be non-leaking (safely reifiable), moreover if
+           [allow_recursive_equations = true] the same assumption
+           is made for the second [type_expr]. *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -273,13 +273,13 @@ val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
         Pattern_env.t -> type_expr -> type_expr -> Btype.TypePairs.t
-        (* Unify the two types given and update the environment with the
-           local constraints. Raise [Unify] if not possible.
+        (* [unify_gadt penv ty1 ty2] unifies [ty1] and [ty2] in
+           [Pattern] mode, possible adding local constraints to the
+           environment in [penv]. Raises [Unify] if not possible.
            Returns the pairs of types that have been equated.
-           Type variables in the first [type_expr] are assumed
-           to be non-leaking (safely reifiable), moreover if
-           [allow_recursive_equations = true] the same assumption
-           is made for the second [type_expr]. *)
+           Type variables in [ty1] are assumed to be non-leaking (safely
+           reifiable), moreover if [penv.allow_recursive_equations = true]
+           the same assumption is made for [ty2]. *)
 val unify_var: Env.t -> type_expr -> type_expr -> unit
         (* Same as [unify], but allow free univars when first type
            is a variable. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -272,8 +272,8 @@ val get_new_abstract_name : Env.t -> string -> string
 val unify: Env.t -> type_expr -> type_expr -> unit
         (* Unify the two types given. Raise [Unify] if not possible. *)
 val unify_gadt:
-        Pattern_env.t -> type_expr -> type_expr -> Btype.TypePairs.t
-        (* [unify_gadt penv ty1 ty2] unifies [ty1] and [ty2] in
+        Pattern_env.t -> pat:type_expr -> type_expr -> Btype.TypePairs.t
+        (* [unify_gadt penv ~pat:ty1 ty2] unifies [ty1] and [ty2] in
            [Pattern] mode, possible adding local constraints to the
            environment in [penv]. Raises [Unify] if not possible.
            Returns the pairs of types that have been equated.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -456,6 +456,8 @@ let unify_pat_types_return_equated_pairs ~refine loc penv ty ty' =
       raise(Typetexp.Error(loc, !!penv, Typetexp.Variant_tags (l1, l2)))
 
 let unify_pat_types_refine ~refine loc penv ty ty' =
+  (* [refine=true] only in calls originating from [check_counter_example_pat],
+     which in turn may contain only non-leaking type variables *)
   ignore (unify_pat_types_return_equated_pairs ~refine loc penv ty ty')
 
 (** [sdesc_for_hint] is used by error messages to report literals in their

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -923,6 +923,8 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
   let unify_res ty_res expected_ty =
     let refine =
       refine || constr.cstr_generalized && no_existentials = None in
+    (* Here [ty_res] contains only fresh (non-leaking) type variables,
+       so the requirement of [unify_gadt] is fulfilled. *)
     unify_pat_types_return_equated_pairs ~refine loc penv ty_res expected_ty
   in
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -445,20 +445,20 @@ let unify_pat_types loc env ty ty' =
 
 (* GADT unification inside solve_Ppat_construct and check_counter_example_pat *)
 let nothing_equated = TypePairs.create 0
-let unify_pat_types_return_equated_pairs ~refine loc penv ty ty' =
+let unify_pat_types_return_equated_pairs ~refine loc penv ~pat ty' =
   try
-    if refine then unify_gadt penv ty ty'
-    else (unify !!penv ty ty'; nothing_equated)
+    if refine then unify_gadt penv ~pat ty'
+    else (unify !!penv pat ty'; nothing_equated)
   with
   | Unify err ->
       raise(Error(loc, !!penv, Pattern_type_clash(err, None)))
   | Tags(l1,l2) ->
       raise(Typetexp.Error(loc, !!penv, Typetexp.Variant_tags (l1, l2)))
 
-let unify_pat_types_refine ~refine loc penv ty ty' =
+let unify_pat_types_refine ~refine loc penv ~pat ty' =
   (* [refine=true] only in calls originating from [check_counter_example_pat],
      which in turn may contain only non-leaking type variables *)
-  ignore (unify_pat_types_return_equated_pairs ~refine loc penv ty ty')
+  ignore (unify_pat_types_return_equated_pairs ~refine loc penv ~pat ty')
 
 (** [sdesc_for_hint] is used by error messages to report literals in their
     original formatting *)
@@ -472,7 +472,7 @@ let unify_head_only ~refine loc penv ty constr =
   let path = cstr_res_type_path constr in
   let decl = Env.find_type path !!penv in
   let ty' = Ctype.newconstr path (Ctype.instance_list decl.type_params) in
-  unify_pat_types_refine ~refine loc penv ty' ty
+  unify_pat_types_refine ~refine loc penv ~pat:ty' ty
 
 (* Creating new conjunctive types is not allowed when typing patterns *)
 (* make all Reither present in open variants *)
@@ -815,7 +815,7 @@ let solve_Ppat_tuple (type a) ~refine loc env (args : a list) expected_ty =
   let vars = List.map (fun _ -> newgenvar ()) args in
   let ty = newgenty (Ttuple vars) in
   let expected_ty = generic_instance expected_ty in
-  unify_pat_types_refine ~refine loc env ty expected_ty;
+  unify_pat_types_refine ~refine loc env ~pat:ty expected_ty;
   vars
 
 let solve_constructor_annotation
@@ -927,7 +927,8 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
       refine || constr.cstr_generalized && no_existentials = None in
     (* Here [ty_res] contains only fresh (non-leaking) type variables,
        so the requirement of [unify_gadt] is fulfilled. *)
-    unify_pat_types_return_equated_pairs ~refine loc penv ty_res expected_ty
+    unify_pat_types_return_equated_pairs ~refine loc penv
+      ~pat:ty_res expected_ty
   in
 
   let ty_args, equated_types, existential_ctyp =
@@ -990,7 +991,7 @@ let solve_Ppat_record_field ~refine loc penv label label_lid record_ty =
   with_local_level_generalize_structure begin fun () ->
     let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
     begin try
-      unify_pat_types_refine ~refine loc penv ty_res (instance record_ty)
+      unify_pat_types_refine ~refine loc penv ~pat:ty_res (instance record_ty)
     with Error(_loc, _env, Pattern_type_clash(err, _)) ->
       raise(Error(label_lid.loc, !!penv,
                   Label_mismatch(label_lid.txt, err)))
@@ -1005,12 +1006,12 @@ let solve_Ppat_array ~refine loc env expected_ty =
   | None ->
       let ty_elt = newgenvar() in
       unify_pat_types_refine ~refine
-        loc env (Predef.type_array ty_elt) expected_ty;
+        loc env ~pat:(Predef.type_array ty_elt) expected_ty;
       ty_elt
 
 let solve_Ppat_lazy ~refine loc env expected_ty =
   let nv = newgenvar () in
-  unify_pat_types_refine ~refine loc env (Predef.type_lazy_t nv)
+  unify_pat_types_refine ~refine loc env ~pat:(Predef.type_lazy_t nv)
     (generic_instance expected_ty);
   nv
 
@@ -1035,7 +1036,8 @@ let solve_Ppat_variant ~refine loc env tag no_arg expected_ty =
   (* PR#7404: allow some_private_tag blindly, as it would not unify with
      the abstract row variable *)
   if tag <> Parmatch.some_private_tag then
-    unify_pat_types_refine ~refine loc env (newgenty(Tvariant row)) expected_ty;
+    unify_pat_types_refine ~refine loc env ~pat:(newgenty(Tvariant row))
+      expected_ty;
   (arg_type, make_row (newvar ()), instance expected_ty)
 
 (* Building the or-pattern corresponding to a polymorphic variant type *)
@@ -2390,7 +2392,7 @@ let rec check_counter_example_pat
   let loc = tp.pat_loc in
   let refine = true in
   let solve_expected (x : pattern) : pattern =
-    unify_pat_types_refine ~refine x.pat_loc penv x.pat_type
+    unify_pat_types_refine ~refine x.pat_loc penv ~pat:x.pat_type
       (instance expected_ty);
     x
   in


### PR DESCRIPTION
This small commit on top of ocaml#13585 add a label to distinguish the "pattern" type from the expected type in `unify_gadt` since the asymmetry is now used to determine if we should try normal unification before pattern unification or not. 